### PR TITLE
Fixed issue #15 BrownianMotion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _build
 
 # macosx
 .DS_Store
+
+# intellij
+.idea/

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -10,3 +10,4 @@ Contributions
 ~~~~~~~~~~~~~
 
 * `Gabinou <https://github.com/Gabinou>`_
+* `MichaelHogervorst <https://github.com/MichaelHogervorst>`_

--- a/stochastic/continuous/brownian_motion.py
+++ b/stochastic/continuous/brownian_motion.py
@@ -95,18 +95,17 @@ class BrownianMotion(GaussianNoise):
         :param bool zero: if True, include :math:`t=0`
         """
         return self._sample_brownian_motion(n, zero)
-    
+
     def _sample_brownian_motion_at(self, times):
         """Generate a Brownian motion at specified times."""
-        
         bm = np.cumsum(self.scale * self._sample_gaussian_noise_at(times))
-        
-        if self.drift != 0:
-            bm += [self.drift * t for t in times]
-        
+
         if times[0] == 0:
             bm = np.insert(bm, 0, [0])
-        
+
+        if self.drift != 0:
+            bm += [self.drift * t for t in times]
+
         return bm
 
     def sample_at(self, times):

--- a/stochastic/continuous/brownian_motion.py
+++ b/stochastic/continuous/brownian_motion.py
@@ -98,11 +98,11 @@ class BrownianMotion(GaussianNoise):
     
     def _sample_brownian_motion_at(self, times):
         """Generate a Brownian motion at specified times."""
-         
+        
         bm = np.cumsum(self.scale * self._sample_gaussian_noise_at(times))
         
         if self.drift != 0:
-            bm += self.drift * times
+            bm += [self.drift * t for t in times]
         
         if times[0] == 0:
             bm = np.insert(bm, 0, [0])

--- a/stochastic/continuous/brownian_motion.py
+++ b/stochastic/continuous/brownian_motion.py
@@ -95,14 +95,19 @@ class BrownianMotion(GaussianNoise):
         :param bool zero: if True, include :math:`t=0`
         """
         return self._sample_brownian_motion(n, zero)
-
+    
     def _sample_brownian_motion_at(self, times):
         """Generate a Brownian motion at specified times."""
-        s = np.cumsum(self._sample_gaussian_noise_at(times))
+         
+        bm = np.cumsum(self.scale * self._sample_gaussian_noise_at(times))
+        
+        if self.drift != 0:
+            bm += self.drift * times
+        
         if times[0] == 0:
-            s = np.insert(s, 0, [0])
-
-        return s
+            bm = np.insert(bm, 0, [0])
+        
+        return bm
 
     def sample_at(self, times):
         """Generate a realization using specified times.


### PR DESCRIPTION
Fixed issue #15 by adding drift and scale to BrownianMotion._sample_brownian_motion_at.

The _sample_gaussian_noise_at(times) return a vector of gaussian noise for the time t's in times. This means that every element in the output vector is scaled by the increments in times. Multiplying the output vector with the scale parameter gives the correct scaling. 

The drift can simply be added to the output vector by adding the product of the drift and times vector, as drift is proportional to time.

The operations are now something like this.
mu_t*t + sig_tdiff * sig_scale * X, for X~N(0,1)

It could have been possible to add the drift part before the np.cumsum by adding the t_diff * drift to each element in the vector, but this is mathematically the same. 

I'm not really experienced with contributing to other libraries, so I hope this all will go well. 