### PR TITLE
remove zero args

### DIFF
--- a/stochastic/base.py
+++ b/stochastic/base.py
@@ -25,10 +25,6 @@ class Checks(object):
         if value < 0:
             raise ValueError(name + " value must be nonnegative.")
 
-    def _check_zero(self, zero):
-        if not isinstance(zero, bool):
-            raise TypeError("Zero inclusion flag must be a boolean.")
-
 
 class Continuous(Checks):
     """Base class to be subclassed to most process classes.
@@ -52,10 +48,10 @@ class Continuous(Checks):
         self._check_positive_number(value, "Time end")
         self._t = float(value)
 
-    def _check_times(self, n, zero):
+    def _check_times(self, n):
         if self._n != n:
             self._n = n
-            self._times = self.times(n, zero)
+            self._times = self.times(n)
 
     def _check_time_sequence(self, times):
         increments = np.diff(times)
@@ -65,12 +61,9 @@ class Continuous(Checks):
             raise ValueError("Times must be strictly increasing.")
         return increments
 
-    def _linspace(self, end, n, zero=True):
+    def _linspace(self, end, n):
         """Generate a linspace from 0 to end for n increments."""
-        if zero:
-            return np.linspace(0, end, n + 1)
-        else:
-            return np.linspace(1.0 * end / n, end, n)
+        return np.linspace(0, end, n + 1)
 
     def sample(self, *args, **kwargs):
         """Sample the process.
@@ -79,13 +72,10 @@ class Continuous(Checks):
         """
         raise NotImplementedError
 
-    def times(self, n, zero=True):
+    def times(self, n):
         """Generate times associated with n increments on [0, t].
 
         :param int n: the number of increments
-        :param bool zero: if True, include :math:`t=0`
         """
         self._check_increments(n)
-        self._check_zero(zero)
-
-        return self._linspace(self.t, n, zero)
+        return self._linspace(self.t, n)

--- a/stochastic/continuous/bessel.py
+++ b/stochastic/continuous/bessel.py
@@ -47,28 +47,23 @@ class BesselProcess(Continuous):
             raise ValueError("Dimension must be positive.")
         self._dim = value
 
-    def _sample_bessel_process(self, n, zero=True):
+    def _sample_bessel_process(self, n):
         """Generate a realization of a Bessel process."""
         self._check_increments(n)
-        self._check_zero(zero)
-
-        samples = [self.brownian_motion.sample(n, zero) for _ in range(self.dim)]
-
+        samples = [self.brownian_motion.sample(n) for _ in range(self.dim)]
         return np.array([np.linalg.norm(coord) for coord in zip(*samples)])
 
     def _sample_bessel_process_at(self, times):
         """Generate a realization of a Bessel process."""
         samples = [self.brownian_motion.sample_at(times) for _ in range(self.dim)]
-
         return np.array([np.linalg.norm(coord) for coord in zip(*samples)])
 
-    def sample(self, n, zero=True):
+    def sample(self, n):
         """Generate a realization.
 
         :param int n: the number of increments to generate
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample_bessel_process(n, zero)
+        return self._sample_bessel_process(n)
 
     def sample_at(self, times):
         """Generate a realization using specified times.

--- a/stochastic/continuous/brownian_bridge.py
+++ b/stochastic/continuous/brownian_bridge.py
@@ -38,33 +38,27 @@ class BrownianBridge(BrownianMotion):
         self._check_number(value, "Time end")
         self._b = value
 
-    def _sample_brownian_bridge(self, n, zero=True, b=None):
+    def _sample_brownian_bridge(self, n, b=None):
         """Generate a realization of a Brownian bridge."""
         if b is None:
             b = self.b
-
-        self._check_times(n, zero)
-
-        bm = self._sample_brownian_motion(n, zero)
-
+        self._check_times(n)
+        bm = self._sample_brownian_motion(n)
         return bm + self._times * (b - bm[-1]) / self.t
 
     def _sample_brownian_bridge_at(self, times, b=None):
         """Generate a realization of a Brownian bridge at times."""
         if b is None:
             b = self.b
-
         bm = self._sample_brownian_motion_at(times)
-
         return bm + np.array(times) * (b - bm[-1]) / times[-1]
 
-    def sample(self, n, zero=True):
+    def sample(self, n):
         """Generate a realization.
 
         :param int n: the number of increments to generate
-        :param bool zero: if True, include time :math:`t=0`
         """
-        return self._sample_brownian_bridge(n, zero)
+        return self._sample_brownian_bridge(n)
 
     def sample_at(self, times, b=None):
         """Generate a realization using specified times.

--- a/stochastic/continuous/brownian_excursion.py
+++ b/stochastic/continuous/brownian_excursion.py
@@ -34,15 +34,12 @@ class BrownianExcursion(BrownianBridge):
     def __repr__(self):
         return "BrownianExcursion(t={t})".format(t=str(self.t))
 
-    def _sample_brownian_excursion(self, n, zero=True):
+    def _sample_brownian_excursion(self, n):
         """Generate a Brownian excursion."""
         brownian_bridge = self._sample_brownian_bridge(n)
         idx_min = np.argmin(brownian_bridge)
         s = np.array([brownian_bridge[(idx_min + idx) % n] - brownian_bridge[idx_min] for idx in range(n + 1)])
-        if zero:
-            return s
-        else:
-            return s[1:]
+        return s
 
     def _sample_brownian_excursion_at(self, times):
         """Generate a Brownian excursion."""
@@ -60,13 +57,12 @@ class BrownianExcursion(BrownianBridge):
         else:
             return s[1:]
 
-    def sample(self, n, zero=True):
+    def sample(self, n):
         """Generate a realization.
 
         :param int n: the number of increments to generate.
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample_brownian_excursion(n, zero)
+        return self._sample_brownian_excursion(n)
 
     def sample_at(self, times):
         """Generate a realization using specified times.

--- a/stochastic/continuous/brownian_meander.py
+++ b/stochastic/continuous/brownian_meander.py
@@ -34,7 +34,7 @@ class BrownianMeander(BrownianBridge):
     def __repr__(self):
         return "BrownianMeander()"
 
-    def _sample_brownian_meander(self, n, b=None, zero=True):
+    def _sample_brownian_meander(self, n, b=None):
         """Generate a Brownian meander realization.
 
         Williams, 1970, or Imhof, 1984.
@@ -44,12 +44,10 @@ class BrownianMeander(BrownianBridge):
         else:
             self._check_nonnegative_number(b, "Right endpoint")
 
-        self._check_times(n, zero)
-
-        bridge_1 = self._sample_brownian_bridge(n, zero)
-        bridge_2 = self._sample_brownian_bridge(n, zero)
-        bridge_3 = self._sample_brownian_bridge(n, zero)
-
+        self._check_times(n)
+        bridge_1 = self._sample_brownian_bridge(n)
+        bridge_2 = self._sample_brownian_bridge(n)
+        bridge_3 = self._sample_brownian_bridge(n)
         return np.sqrt((b * self._times / self.t + bridge_1) ** 2 + bridge_2 ** 2 + bridge_3 ** 2)
 
     def _sample_brownian_meander_at(self, times, b=None):
@@ -68,16 +66,15 @@ class BrownianMeander(BrownianBridge):
 
         return np.sqrt((b * times / times[-1] + bridge_1) ** 2 + bridge_2 ** 2 + bridge_3 ** 2)
 
-    def sample(self, n, b=None, zero=True):
+    def sample(self, n, b=None):
         r"""Generate a realization.
 
         :param int n: the number of increments to generate
         :param float b: the nonnegative right hand endpoint of the meander. If
             not provided, one is randomly selected from a :math:`\sqrt{2E}`
             random variable where :math:`E` is exponential.
-        :param bool zero: if True, include time :math:`t=0`
         """
-        return self._sample_brownian_meander(n, b, zero)
+        return self._sample_brownian_meander(n, b)
 
     def sample_at(self, times, b=None):
         r"""Generate a realization using specified times.

--- a/stochastic/continuous/brownian_motion.py
+++ b/stochastic/continuous/brownian_motion.py
@@ -58,33 +58,31 @@ class BrownianMotion(GaussianNoise):
         self._check_positive_number(value, "Scale")
         self._scale = value
 
-    def _sample_brownian_motion(self, n, zero=True):
+    def _sample_brownian_motion(self, n):
         """Generate a realization of Brownian Motion.
 
         Generate a Brownian motion realization with n increments. If zero is
         True then include W_0 = 0.
         """
-        self._check_zero(zero)
-
         # Some opt for repeats
         if self.drift != 0 and (self._line is None or len(self._line) != n):
             self._n = n
-            self._line = self._linspace(self.drift, n, zero)
+            self._line = self._linspace(self.drift, n)
 
-        bm = np.cumsum(self.scale * self._sample_gaussian_noise(n, zero))
+        bm = np.cumsum(self.scale * self._sample_gaussian_noise(n))
+        bm = np.insert(bm, [0], 0)
 
         if self.drift != 0:
             return self._line + bm
         else:
             return bm
 
-    def sample(self, n, zero=True):
+    def sample(self, n):
         """Generate a realization.
 
         :param int n: the number of increments to generate
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample_brownian_motion(n, zero)
+        return self._sample_brownian_motion(n)
 
     def _sample_brownian_motion_at(self, times):
         """Generate a Brownian motion at specified times."""

--- a/stochastic/continuous/cauchy.py
+++ b/stochastic/continuous/cauchy.py
@@ -23,17 +23,13 @@ class CauchyProcess(Continuous):
         super(CauchyProcess, self).__init__(t)
         self.brownian_motion = BrownianMotion(t)
 
-    def _sample_cauchy_process(self, n, zero=True):
+    def _sample_cauchy_process(self, n):
         """Generate a realization of a Cauchy process."""
         self._check_increments(n)
-        self._check_zero(zero)
 
         delta_t = 1.0 * self.t / n
         times = np.cumsum(levy.rvs(loc=0, scale=delta_t ** 2 / 2, size=n))
-
-        if zero:
-            times = np.insert(times, 0, [0])
-
+        times = np.insert(times, 0, [0])
         return self.brownian_motion.sample_at(times)
 
     def _sample_cauchy_process_at(self, times):
@@ -53,13 +49,12 @@ class CauchyProcess(Continuous):
 
         return self.brownian_motion.sample_at(ts)
 
-    def sample(self, n, zero=True):
+    def sample(self, n):
         """Generate a realization.
 
         :param int n: the number of increments to generate.
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample_cauchy_process(n, zero)
+        return self._sample_cauchy_process(n)
 
     def sample_at(self, times):
         """Generate a realization using specified times.

--- a/stochastic/continuous/fractional_brownian_motion.py
+++ b/stochastic/continuous/fractional_brownian_motion.py
@@ -40,19 +40,16 @@ class FractionalBrownianMotion(FractionalGaussianNoise):
     def __repr__(self):
         return "FractionalBrownianMotion(hurst={h}, t={t})".format(t=str(self.t), h=str(self.hurst))
 
-    def _sample_fractional_brownian_motion(self, n, zero=True):
+    def _sample_fractional_brownian_motion(self, n):
         """Generate a realization of fractional Brownian motion."""
         fgn = self._sample_fractional_gaussian_noise(n)
         fbm = fgn.cumsum()
-        if zero:
-            fbm = np.insert(fbm, [0], 0)
-
+        fbm = np.insert(fbm, [0], 0)
         return fbm
 
-    def sample(self, n, zero=True):
+    def sample(self, n):
         """Generate a realization.
 
         :param int n: the number of increments to generate
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample_fractional_brownian_motion(n, zero)
+        return self._sample_fractional_brownian_motion(n)

--- a/stochastic/continuous/gamma.py
+++ b/stochastic/continuous/gamma.py
@@ -89,21 +89,16 @@ class GammaProcess(Continuous):
         self._check_positive_number(value, "Variance parameter")
         self._variance = value
 
-    def _sample_gamma_process(self, n, zero=True):
+    def _sample_gamma_process(self, n):
         """Sample a Gamma process."""
         self._check_increments(n)
-        self._check_zero(zero)
         delta_t = 1.0 * self.t / n
 
         shape = 1.0 * self.mean ** 2 * delta_t / self.variance
         scale = 1.0 * self.variance / self.mean
 
         samples = np.cumsum(np.random.gamma(shape=shape, scale=scale, size=n))
-
-        if zero:
-            return np.concatenate(([0], samples))
-        else:
-            return samples
+        return np.concatenate(([0], samples))
 
     def _sample_gamma_process_at(self, times):
         """Sample a Gamma process at specific times."""
@@ -122,17 +117,17 @@ class GammaProcess(Continuous):
 
         return np.cumsum(s)
 
-    def sample(self, n, zero=True):
+    def sample(self, n):
         """Generate a realization.
 
         :param int n: the number of increments to generate
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample_gamma_process(n, zero)
+        return self._sample_gamma_process(n)
 
     def sample_at(self, times):
         """Generate a realization at specified times.
 
-        :param int times: the times at which to generate the realization
+        :param times: a vector of increasing time values at which to generate
+            the realization
         """
         return self._sample_gamma_process_at(times)

--- a/stochastic/continuous/geometric_brownian_motion.py
+++ b/stochastic/continuous/geometric_brownian_motion.py
@@ -68,41 +68,40 @@ class GeometricBrownianMotion(Continuous):
         self._check_positive_number(value, "Volatility")
         self._volatility = value
 
-    def _sample_geometric_brownian_motion(self, n, initial=1, zero=True):
+    def _sample_geometric_brownian_motion(self, n, initial=1.0):
         """Generate a realization of geometric Brownian motion."""
         self._check_increments(n)
         self._check_positive_number(initial, "Initial")
-        self._check_zero(zero)
 
         # Opt for repeated use
         if self._n != n:
             self._n = n
-            self._line = self._linspace(self.drift - self.volatility ** 2 / 2.0, n, zero)
+            self._line = self._linspace(self.drift - self.volatility ** 2 / 2.0, n)
 
-        noise = self.volatility * self._brownian_motion.sample(n, zero)
+        noise = self.volatility * self._brownian_motion.sample(n)
 
         return initial * np.exp(self._line + noise)
 
-    def _sample_geometric_brownian_motion_at(self, times, initial=1):
+    def _sample_geometric_brownian_motion_at(self, times, initial=1.0):
         """Generate a realization of geometric Brownian motion."""
         line = [(self.drift - self.volatility ** 2 / 2.0) * t for t in times]
         noise = self.volatility * self._brownian_motion.sample_at(times)
 
         return initial * np.exp(line + noise)
 
-    def sample(self, n, initial=1, zero=True):
+    def sample(self, n, initial=1):
         """Generate a realization.
 
         :param int n: the number of increments to generate.
         :param float initial: the initial value of the process :math:`S_0`.
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample_geometric_brownian_motion(n, initial, zero)
+        return self._sample_geometric_brownian_motion(n, initial)
 
     def sample_at(self, times, initial=1):
         """Generate a realization using specified times.
 
         :param times: a vector of increasing time values at which to generate
             the realization
+        :param float initial: the initial value of the process :math:`S_0`.
         """
         return self._sample_geometric_brownian_motion_at(times, initial)

--- a/stochastic/continuous/inverse_gaussian.py
+++ b/stochastic/continuous/inverse_gaussian.py
@@ -84,13 +84,11 @@ class InverseGaussianProcess(Continuous):
             raise ValueError("Mean must be monotonically increasing.")
         return delta
 
-    def _sample_inverse_gaussian_process(self, n, zero=True):
+    def _sample_inverse_gaussian_process(self, n):
         """Generate a realization of the inverse Gaussian process.
 
         Generate an inverse Gaussian process realization with n increments.
-        If zero is True then include IG_0 = 0.
         """
-        self._check_zero(zero)
         times = self.times(n)
 
         if self._n != n:
@@ -121,18 +119,15 @@ class InverseGaussianProcess(Continuous):
                 ign.append(m ** 2 / x)
 
         ig = np.array(ign).cumsum()
-        if zero:
-            ig = np.insert(ig, [0], 0)
-
+        ig = np.insert(ig, [0], 0)
         return ig
 
-    def sample(self, n, zero=True):
+    def sample(self, n):
         """Generate a realization.
 
         :param int n: the number of increments to generate
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample_inverse_gaussian_process(n, zero)
+        return self._sample_inverse_gaussian_process(n)
 
     def _sample_inverse_gaussian_process_at(self, times):
         """Generate an inverse Gaussian process at specified times."""

--- a/stochastic/continuous/mixed_poisson.py
+++ b/stochastic/continuous/mixed_poisson.py
@@ -23,10 +23,11 @@ class MixedPoissonProcess(PoissonProcess):
     :param dict rate_kwargs: keyword args for ``rate_func``
     """
 
-    def __init__(self, rate_func, rate_args=(), rate_kwargs={}):
+    def __init__(self, rate_func, rate_args=None, rate_kwargs=None):
         self.rate_func = rate_func
-        self.rate_args = rate_args
-        self.rate_kwargs = rate_kwargs
+        self.rate_args = rate_args if rate_args is not None else tuple()
+        self.rate_kwargs = rate_kwargs if rate_kwargs is not None else dict()
+        super().__init__(rate=1)
 
     def __str__(self):
         return "Mixed Poisson process with random rate."
@@ -86,7 +87,7 @@ class MixedPoissonProcess(PoissonProcess):
         """Generate a rate variate."""
         return self.rate_func(*self.rate_args, **self.rate_kwargs)
 
-    def sample(self, n=None, length=None, zero=True):
+    def sample(self, n=None, length=None):
         """Generate a realization.
 
         Exactly one of `n` and `length` must be provided. Generates a random
@@ -96,7 +97,6 @@ class MixedPoissonProcess(PoissonProcess):
         :param int n: the number of arrivals to simulate
         :param int length: the length of time to simulate; will generate
             arrivals until length is met or exceeded.
-        :param bool zero: if True, include :math:`t=0`
         """
         self.rate = self._sample_rate()
-        return self._sample_poisson_process(n, length, zero)
+        return self._sample_poisson_process(n, length)

--- a/stochastic/continuous/multifractional_brownian_motion.py
+++ b/stochastic/continuous/multifractional_brownian_motion.py
@@ -75,7 +75,7 @@ class MultifractionalBrownianMotion(Continuous):
             if h <= 0 or h >= 1:
                 raise ValueError("Hurst range must be on interval (0, 1).")
 
-    def _sample_multifractional_brownian_motion(self, n, zero=True):
+    def _sample_multifractional_brownian_motion(self, n):
         """Generate Riemann-Liouville mBm."""
         gn = np.random.normal(0.0, 1.0, n)
         if self._n != n:
@@ -83,10 +83,7 @@ class MultifractionalBrownianMotion(Continuous):
             self._dt = 1.0 * self.t / self._n
             self._ts = self.times(n)
             self._check_hurst(self.hurst)
-        if zero:
-            mbm = [0]
-        else:
-            mbm = []
+        mbm = [0]
         coefs = [(g / np.sqrt(self._dt)) * self._dt for g in gn]
         for k in range(1, self._n + 1):
             weights = [self._w(t, self._hs[k]) for t in self._ts[1 : k + 1]]
@@ -94,13 +91,12 @@ class MultifractionalBrownianMotion(Continuous):
             mbm.append(sum(seq))
         return np.array(mbm)
 
-    def sample(self, n, zero=True):
+    def sample(self, n):
         """Generate a realization.
 
         :param int n: the number of increments to generate
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample_multifractional_brownian_motion(n, zero)
+        return self._sample_multifractional_brownian_motion(n)
 
     def _w(self, t, hurst):
         """Get the Riemann-Liouville method weight for time t."""

--- a/stochastic/continuous/poisson.py
+++ b/stochastic/continuous/poisson.py
@@ -38,7 +38,7 @@ class PoissonProcess(Checks):
         self._check_nonnegative_number(value, "Arrival rate")
         self._rate = value
 
-    def _sample_poisson_process(self, n=None, length=None, zero=True):
+    def _sample_poisson_process(self, n=None, length=None):
         """Generate a realization of a Poisson process.
 
         Generate a poisson process sample up to count of length if time=False,
@@ -50,17 +50,12 @@ class PoissonProcess(Checks):
             exponentials = np.random.exponential(scale=1.0 / self.rate, size=n)
 
             s = np.array([0] + list(np.cumsum(exponentials)))
-            if zero:
-                return s
-            else:
-                return s[1:]
+            return s
         elif length is not None:
             self._check_positive_number(length, "Sample length")
 
             t = 0
-            times = []
-            if zero:
-                times.append(0)
+            times = [0]
             exp_rate = 1.0 / self.rate
 
             while t < length:
@@ -71,7 +66,7 @@ class PoissonProcess(Checks):
         else:
             raise ValueError("Must provide either argument n or length.")
 
-    def sample(self, n=None, length=None, zero=True):
+    def sample(self, n=None, length=None):
         """Generate a realization.
 
         Exactly one of `n` and `length` must be provided.
@@ -79,9 +74,8 @@ class PoissonProcess(Checks):
         :param int n: the number of arrivals to simulate
         :param int length: the length of time to simulate; will generate
             arrivals until length is met or exceeded.
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample_poisson_process(n, length, zero)
+        return self._sample_poisson_process(n, length)
 
     def times(self, *args, **kwargs):
         """Disallow times for this process."""

--- a/stochastic/continuous/squared_bessel.py
+++ b/stochastic/continuous/squared_bessel.py
@@ -21,12 +21,11 @@ class SquaredBesselProcess(BesselProcess):
         for the process
     """
 
-    def _sample_squared_bessel_process(self, n, zero=True):
+    def _sample_squared_bessel_process(self, n):
         """Generate a realization of a squared Bessel process."""
         self._check_increments(n)
-        self._check_zero(zero)
 
-        samples = [self.brownian_motion.sample(n, zero) for _ in range(self.dim)]
+        samples = [self.brownian_motion.sample(n) for _ in range(self.dim)]
 
         return np.array([sum(map(lambda x: x ** 2, coord)) for coord in zip(*samples)])
 
@@ -36,13 +35,12 @@ class SquaredBesselProcess(BesselProcess):
 
         return np.array([sum(map(lambda x: x ** 2, coord)) for coord in zip(*samples)])
 
-    def sample(self, n, zero=True):
+    def sample(self, n):
         """Generate a realization.
 
         :param int n: the number of increments to generate
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample_squared_bessel_process(n, zero)
+        return self._sample_squared_bessel_process(n)
 
     def sample_at(self, times):
         """Generate a realization using specified times.

--- a/stochastic/continuous/variance_gamma.py
+++ b/stochastic/continuous/variance_gamma.py
@@ -66,10 +66,9 @@ class VarianceGammaProcess(Continuous):
         self._check_positive_number(value, "Scale")
         self._scale = value
 
-    def _sample_variance_gamma_process(self, n, zero=True):
+    def _sample_variance_gamma_process(self, n):
         """Generate a realization of a variance gamma process."""
         self._check_increments(n)
-        self._check_zero(zero)
 
         delta_t = 1.0 * self.t / n
         shape = delta_t / self.variance
@@ -82,10 +81,7 @@ class VarianceGammaProcess(Continuous):
 
         samples = np.cumsum(increments)
 
-        if zero:
-            return np.concatenate(([0], samples))
-        else:
-            return samples
+        return np.concatenate(([0], samples))
 
     def _sample_variance_gamma_process_at(self, times):
         """Generate a realization of a variance gamma process."""
@@ -108,13 +104,12 @@ class VarianceGammaProcess(Continuous):
             samples = np.insert(samples, 0, [0])
         return samples
 
-    def sample(self, n, zero=True):
+    def sample(self, n):
         """Generate a realization.
 
         :param int n: the number of increments to generate
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample_variance_gamma_process(n, zero)
+        return self._sample_variance_gamma_process(n)
 
     def sample_at(self, times):
         """Generate a realization using specified times.

--- a/stochastic/diffusion/__init__.py
+++ b/stochastic/diffusion/__init__.py
@@ -1,17 +1,11 @@
-from stochastic.diffusion.constant_elasticity_variance import CEVProcess
 from stochastic.diffusion.constant_elasticity_variance import ConstantElasticityVarianceProcess
-from stochastic.diffusion.cox_ingersoll_ross import CIRProcess
 from stochastic.diffusion.cox_ingersoll_ross import CoxIngersollRossProcess
 from stochastic.diffusion.ornstein_uhlenbeck import OrnsteinUhlenbeckProcess
-from stochastic.diffusion.ornstein_uhlenbeck import OUProcess
 from stochastic.diffusion.vasicek import VasicekProcess
 
 __all__ = [
-    "CEVProcess",
-    "CIRProcess",
     "ConstantElasticityVarianceProcess",
     "CoxIngersollRossProcess",
     "OrnsteinUhlenbeckProcess",
-    "OUProcess",
     "VasicekProcess",
 ]

--- a/stochastic/diffusion/constant_elasticity_variance.py
+++ b/stochastic/diffusion/constant_elasticity_variance.py
@@ -73,9 +73,3 @@ class ConstantElasticityVarianceProcess(OrnsteinUhlenbeckProcess):
     def _volatility(self, arg):
         """O-U Volatility coefficient."""
         return arg ** self.gamma
-
-
-class CEVProcess(ConstantElasticityVarianceProcess):
-    """Alias for ConstantElasticityVarianceProcess."""
-
-    pass

--- a/stochastic/diffusion/cox_ingersoll_ross.py
+++ b/stochastic/diffusion/cox_ingersoll_ross.py
@@ -42,9 +42,3 @@ class CoxIngersollRossProcess(OrnsteinUhlenbeckProcess):
     def _volatility(self, arg):
         """Volatility term."""
         return np.sqrt(arg)
-
-
-class CIRProcess(CoxIngersollRossProcess):
-    """Alias for CoxIngersollRossProcess."""
-
-    pass

--- a/stochastic/diffusion/ornstein_uhlenbeck.py
+++ b/stochastic/diffusion/ornstein_uhlenbeck.py
@@ -83,35 +83,25 @@ class OrnsteinUhlenbeckProcess(Continuous):
         """
         return 1
 
-    def _sample(self, n, initial=1, zero=True):
+    def _sample(self, n, initial=1.0):
         """Generate a realization of a Ornstein-Uhlenbeck process."""
         self._check_increments(n)
-        self._check_zero(zero)
         self._check_number(initial, "Initial")
 
         delta_t = 1.0 * self.t / n
         gns = self.gn.sample(n)
 
-        s = []
-        if zero:
-            s.append(initial)
+        s = [initial]
         for k in range(n):
             initial += self.speed * (self.mean - initial) * delta_t + self.vol * self._volatility(initial) * gns[k]
             s.append(initial)
 
         return np.array(s)
 
-    def sample(self, n, initial=1, zero=True):
+    def sample(self, n, initial=1):
         """Generate a realization.
 
         :param int n: the number of increments to generate
         :param float initial: the initial value of the process
-        :param bool zero: if True, include :math:`t=0`
         """
-        return self._sample(n, initial, zero)
-
-
-class OUProcess(OrnsteinUhlenbeckProcess):
-    """Alias for OrnsteinUhlenbeckProcess."""
-
-    pass
+        return self._sample(n, initial)

--- a/stochastic/discrete/chinese_restaurant.py
+++ b/stochastic/discrete/chinese_restaurant.py
@@ -103,7 +103,7 @@ class ChineseRestaurantProcess(Checks):
             s.append(table)
 
         if partition:
-            return np.array([np.array(t) for t in c])
+            return np.array([np.array(t) for t in c], dtype=object)
         else:
             return np.array(s)
 
@@ -134,7 +134,7 @@ class ChineseRestaurantProcess(Checks):
                 partition.append([])
             partition[table].append(idx)
 
-        return np.array([np.array(t) for t in partition])
+        return np.array([np.array(t) for t in partition], dtype=object)
 
     def partition_to_sequence(self, partition):
         """Create a sequence from a partition.

--- a/stochastic/discrete/markov_chain.py
+++ b/stochastic/discrete/markov_chain.py
@@ -19,12 +19,17 @@ class MarkovChain(Checks):
         not provided, each state has equal initial probability.
     """
 
-    def __init__(self, transition=[[0.5, 0.5], [0.5, 0.5]], initial=None):
-        self.transition = transition
+    def __init__(self, transition=None, initial=None):
+        if transition is None:
+            self.transition = [[0.5, 0.5], [0.5, 0.5]]
+        else:
+            self.transition = transition
+
         if initial is None:
-            self.initial = [1.0 / len(self.transition) for t in self.transition]
+            self.initial = [1.0 / len(self.transition) for _ in self.transition]
         else:
             self.initial = initial
+
         self.num_states = len(self.initial)
 
     def __str__(self):

--- a/stochastic/discrete/moran.py
+++ b/stochastic/discrete/moran.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 
-class MoranProcess(object):
+class MoranProcess:
     """Moran process.
 
     .. image:: _static/moran_process.png

--- a/stochastic/discrete/random_walk.py
+++ b/stochastic/discrete/random_walk.py
@@ -78,20 +78,16 @@ class RandomWalk(Checks):
     def __repr__(self):
         return "RandomWalk(steps={s}, weights={w})".format(s=str(self.steps), w=str(self.weights))
 
-    def _sample_random_walk(self, n, zero=True):
+    def _sample_random_walk(self, n):
         """Generate a random walk."""
-        if zero:
-            return np.array([0] + list(np.cumsum(self._sample_random_walk_increments(n))))
-        else:
-            return np.cumsum(self._sample_random_walk_increments(n))
+        return np.array([0] + list(np.cumsum(self._sample_random_walk_increments(n))))
 
-    def sample(self, n, zero=True):
+    def sample(self, n):
         """Generate a sample random walk.
 
         :param int n: the number of steps to generate
-        :param bool zero: if True include the step at :math:`t=0`
         """
-        return self._sample_random_walk(n, zero)
+        return self._sample_random_walk(n)
 
     def _sample_random_walk_increments(self, n):
         """Generate a sample of random walk increments."""

--- a/stochastic/noise/colored_noise.py
+++ b/stochastic/noise/colored_noise.py
@@ -34,6 +34,8 @@ class ColoredNoise(Continuous):
         super(ColoredNoise, self).__init__(t)
         self.beta = beta
         self._n = None
+        self._half = None
+        self._frequencies = None
         self._scale = None
 
     def __str__(self):
@@ -60,13 +62,13 @@ class ColoredNoise(Continuous):
         n = n + 1
         if self._n != n:
             self._n = n
-            half = (n + 1) // 2
 
-            frequencies = np.fft.fftfreq(n, self.t)
-            self._scale = [np.sqrt(0.5 * (1 / w) ** self.beta) for w in frequencies[1:half]]
+            self._half = (n + 1) // 2
+            self._frequencies = np.fft.fftfreq(n, self.t)
+            self._scale = [np.sqrt(0.5 * (1 / w) ** self.beta) for w in self._frequencies[1 : self._half]]
 
-        gn_real = np.random.normal(size=half - 1)
-        gn_imag = np.random.normal(size=half - 1)
+        gn_real = np.random.normal(size=self._half - 1)
+        gn_imag = np.random.normal(size=self._half - 1)
         fft = self._scale * (gn_real + 1j * gn_imag)
 
         if n % 2 == 0:
@@ -74,7 +76,7 @@ class ColoredNoise(Continuous):
                 (
                     [0],
                     fft,
-                    [np.sqrt(0.5 * (1 / -frequencies[half]) ** self.beta) * np.random.normal()],
+                    [np.sqrt(0.5 * (1 / -self._frequencies[self._half]) ** self.beta) * np.random.normal()],
                     np.conj(fft)[::-1],
                 )
             )
@@ -107,7 +109,7 @@ class PinkNoise(ColoredNoise):
     """
 
     def __init__(self, t=1):
-        super(PinkNoise, self).__init__(1, t)
+        super(PinkNoise, self).__init__(beta=1, t=t)
 
 
 class WhiteNoise(ColoredNoise):
@@ -124,7 +126,7 @@ class WhiteNoise(ColoredNoise):
     """
 
     def __init__(self, t=1):
-        super(WhiteNoise, self).__init__(0, t)
+        super(WhiteNoise, self).__init__(beta=0, t=t)
 
 
 class RedNoise(ColoredNoise):
@@ -141,7 +143,7 @@ class RedNoise(ColoredNoise):
     """
 
     def __init__(self, t=1):
-        super(RedNoise, self).__init__(2, t)
+        super(RedNoise, self).__init__(beta=2, t=t)
 
 
 class BrownianNoise(RedNoise):
@@ -156,7 +158,6 @@ class BrownianNoise(RedNoise):
     :param float t: the right hand endpoint of the time interval :math:`[0,t]`
         for the process
     """
-
     pass
 
 
@@ -174,7 +175,7 @@ class BlueNoise(ColoredNoise):
     """
 
     def __init__(self, t=1):
-        super(BlueNoise, self).__init__(-1, t)
+        super().__init__(beta=-1, t=t)
 
 
 class VioletNoise(ColoredNoise):
@@ -191,4 +192,4 @@ class VioletNoise(ColoredNoise):
     """
 
     def __init__(self, t=1):
-        super(VioletNoise, self).__init__(-2, t)
+        super().__init__(beta=-2, t=t)

--- a/stochastic/noise/gaussian_noise.py
+++ b/stochastic/noise/gaussian_noise.py
@@ -25,7 +25,7 @@ class GaussianNoise(Continuous):
     def __repr__(self):
         return "GaussianNoise(t={t})".format(t=str(self.t))
 
-    def _sample_gaussian_noise(self, n, zero=False):
+    def _sample_gaussian_noise(self, n):
         """Generate a realization of Gaussian noise.
 
         Generate a Gaussian noise realization with n increments.
@@ -35,21 +35,15 @@ class GaussianNoise(Continuous):
 
         noise = np.random.normal(scale=np.sqrt(delta_t), size=n)
 
-        if zero:
-            noise = np.insert(noise, [0], 0)
-
         return noise
 
-    def _sample_gaussian_noise_at(self, times, zero=False):
+    def _sample_gaussian_noise_at(self, times):
         """Generate Gaussian noise increments at specified times from zero."""
         if times[0] != 0:
             times = np.concatenate(([0], times))
         increments = self._check_time_sequence(times)
 
         noise = np.array([np.random.normal(scale=np.sqrt(inc)) for inc in increments])
-
-        if zero:
-            noise = np.insert(noise, [0], 0)
 
         return noise
 

--- a/tests/base/conftest.py
+++ b/tests/base/conftest.py
@@ -28,11 +28,6 @@ def nonnegative_number_fixture(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False, 0])
-def zero_fixture(request):
-    return request.param
-
-
 has_negative = [-5, -4, 0, 4, 5]
 bad_order = [0, 3, 2, 5]
 good_example = list(range(10))
@@ -44,11 +39,6 @@ def times_fixture(request):
 
 
 # Continuous class fixtures
-@pytest.fixture(params=[True, False])
-def zero(request):
-    return request.param
-
-
 @pytest.fixture(params=[16])
 def n(request):
     return request.param

--- a/tests/base/test_base_checks.py
+++ b/tests/base/test_base_checks.py
@@ -41,12 +41,3 @@ def test_check_nonnegative_number(nonnegative_number_fixture, parameter_name_fix
             checks._check_nonnegative_number(nonnegative_number_fixture, parameter_name_fixture)
     else:
         assert checks._check_nonnegative_number(nonnegative_number_fixture, parameter_name_fixture) is None
-
-
-def test_check_zero(zero_fixture):
-    checks = Checks()
-    if not isinstance(zero_fixture, bool):
-        with pytest.raises(TypeError):
-            checks._check_zero(zero_fixture)
-    else:
-        assert checks._check_zero(zero_fixture) is None

--- a/tests/base/test_base_continuous.py
+++ b/tests/base/test_base_continuous.py
@@ -4,22 +4,19 @@ import pytest
 from stochastic.base import Continuous
 
 
-def test_check_times(end, n, zero, mocker):
+def test_check_times(end, n, mocker):
     continuous = Continuous(end)
     mocker.patch("stochastic.base.Continuous.times")
     assert continuous._n is None
-    continuous._check_times(n, zero)
+    continuous._check_times(n)
     assert continuous._n == n
     assert continuous.times.called
 
 
-def test_linspace(end, n, zero):
+def test_linspace(end, n):
     continuous = Continuous(end)
-    ls = continuous._linspace(end, n, zero)
-    if zero:
-        assert (ls == np.linspace(0, end, n + 1)).all()
-    else:
-        assert (ls == np.linspace(1.0 * end / n, end, n)).all()
+    ls = continuous._linspace(end, n)
+    assert (ls == np.linspace(0, end, n + 1)).all()
 
 
 def test_sample(end, n):
@@ -28,10 +25,10 @@ def test_sample(end, n):
         continuous.sample(n)
 
 
-def test_times(end, n, zero, mocker):
+def test_times(end, n, mocker):
     continuous = Continuous(end)
     mocker.patch("stochastic.base.Continuous._linspace")
-    continuous.times(n, zero)
+    continuous.times(n)
     assert continuous._linspace.called
 
 

--- a/tests/continuous/conftest.py
+++ b/tests/continuous/conftest.py
@@ -22,11 +22,6 @@ def n(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def zero(request):
-    return request.param
-
-
 # Generate some random times for the sample_at() method
 times_random = np.cumsum(np.abs(np.random.normal(size=16)))
 times_random_zero = np.cumsum([0] + list(np.abs(np.random.normal(size=16))))

--- a/tests/continuous/test_bessel.py
+++ b/tests/continuous/test_bessel.py
@@ -13,18 +13,18 @@ def test_bessel_str_repr(dim, t):
 def test_bessel_init(dim_fixture, t):
     if not isinstance(dim_fixture, int):
         with pytest.raises(TypeError):
-            instance = BesselProcess(dim_fixture, t)
+            _ = BesselProcess(dim_fixture, t)
     elif dim_fixture < 1:
         with pytest.raises(ValueError):
-            instance = BesselProcess(dim_fixture, t)
+            _ = BesselProcess(dim_fixture, t)
     else:
-        instance = BesselProcess(dim_fixture, t)
+        _ = BesselProcess(dim_fixture, t)
 
 
-def test_bessel_sample(dim, t, n, zero):
+def test_bessel_sample(dim, t, n):
     instance = BesselProcess(dim, t)
-    s = instance.sample(n, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n)
+    assert len(s) == n + 1
 
 
 def test_bessel_sample_at(dim, t, times):

--- a/tests/continuous/test_brownian_bridge.py
+++ b/tests/continuous/test_brownian_bridge.py
@@ -13,13 +13,13 @@ def test_brownian_bridge_str_repr(b, t):
     assert isinstance(str(instance), str)
 
 
-def test_brownian_bridge_sample(b, t, n, zero, threshold):
+def test_brownian_bridge_sample(b, t, n, threshold):
     if b is not None:
         instance = BrownianBridge(b, t)
     else:
         instance = BrownianBridge(t)
-    s = instance.sample(n, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n)
+    assert len(s) == n + 1
     assert s[-1] == pytest.approx(instance.b, threshold)
 
 

--- a/tests/continuous/test_brownian_excursion.py
+++ b/tests/continuous/test_brownian_excursion.py
@@ -10,13 +10,12 @@ def test_brownian_excursion_str_repr(t):
     assert isinstance(str(instance), str)
 
 
-def test_brownian_excursion_sample(t, n, zero, threshold):
+def test_brownian_excursion_sample(t, n, threshold):
     instance = BrownianExcursion(t)
-    s = instance.sample(n, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n)
+    assert len(s) == n + 1
     assert (s >= 0).all()
-    if zero:
-        assert s[0] == pytest.approx(0, threshold)
+    assert s[0] == pytest.approx(0, threshold)
     assert s[-1] == pytest.approx(0, threshold)
 
 

--- a/tests/continuous/test_brownian_meander.py
+++ b/tests/continuous/test_brownian_meander.py
@@ -10,13 +10,12 @@ def test_brownian_meander_str_repr(t):
     assert isinstance(str(instance), str)
 
 
-def test_brownian_meander_sample(t, n, b, zero, threshold):
+def test_brownian_meander_sample(t, n, b, threshold):
     instance = BrownianMeander(t)
-    s = instance.sample(n, b, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n, b)
+    assert len(s) == n + 1
     assert (s >= 0).all()
-    if zero:
-        assert s[0] == pytest.approx(0, threshold)
+    assert s[0] == pytest.approx(0, threshold)
 
 
 def test_brownian_meander_sample_at(t, times, b, threshold):

--- a/tests/continuous/test_brownian_motion.py
+++ b/tests/continuous/test_brownian_motion.py
@@ -10,10 +10,10 @@ def test_brownian_motion_str_repr(drift, scale, t):
     assert isinstance(str(instance), str)
 
 
-def test_brownian_motion_sample(drift, scale, t, n, zero, threshold):
+def test_brownian_motion_sample(drift, scale, t, n, threshold):
     instance = BrownianMotion(drift, scale, t)
-    s = instance.sample(n, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n)
+    assert len(s) == n + 1
 
 
 def test_brownian_motion_sample_at(drift, scale, t, times, threshold):

--- a/tests/continuous/test_cauchy.py
+++ b/tests/continuous/test_cauchy.py
@@ -10,10 +10,10 @@ def test_cauchy_process_str_repr(t):
     assert isinstance(str(instance), str)
 
 
-def test_cauchy_process_sample(t, n, zero, threshold):
+def test_cauchy_process_sample(t, n, threshold):
     instance = CauchyProcess(t)
-    s = instance.sample(n, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n)
+    assert len(s) == n + 1
 
 
 def test_cauchy_process_sample_at(t, times, threshold):

--- a/tests/continuous/test_fractional_brownian_motion.py
+++ b/tests/continuous/test_fractional_brownian_motion.py
@@ -10,7 +10,7 @@ def test_fractional_brownian_motion_str_repr(hurst, t):
     assert isinstance(str(instance), str)
 
 
-def test_fractional_brownian_motion_sample(hurst, t, n, zero, threshold):
+def test_fractional_brownian_motion_sample(hurst, t, n, threshold):
     instance = FractionalBrownianMotion(hurst, t)
-    s = instance.sample(n, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n)
+    assert len(s) == n + 1

--- a/tests/continuous/test_gamma.py
+++ b/tests/continuous/test_gamma.py
@@ -10,7 +10,7 @@ def test_gamma_process_init(mean_fixture, variance_fixture, rate_fixture, scale_
     all_params = first_params + second_params
     if all_params != 2 or (first_params != 2 and second_params != 2):
         with pytest.raises((TypeError, ValueError)):
-            instance = GammaProcess(mean_fixture, variance_fixture, rate_fixture, scale_fixture, t)
+            _ = GammaProcess(mean_fixture, variance_fixture, rate_fixture, scale_fixture, t)
     else:
         instance = GammaProcess(mean_fixture, variance_fixture, rate_fixture, scale_fixture, t)
         assert isinstance(repr(instance), str)
@@ -23,10 +23,10 @@ def test_gamma_process_str_repr(mean, variance, t):
     assert isinstance(str(instance), str)
 
 
-def test_gamma_process_sample(mean, variance, t, n, zero, threshold):
+def test_gamma_process_sample(mean, variance, t, n, threshold):
     instance = GammaProcess(mean, variance, t=t)
-    s = instance.sample(n, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n)
+    assert len(s) == n + 1
 
 
 def test_gamma_process_sample_at(mean, variance, t, times, threshold):

--- a/tests/continuous/test_geometric_brownian_motion.py
+++ b/tests/continuous/test_geometric_brownian_motion.py
@@ -10,10 +10,10 @@ def test_geometric_brownian_motion_str_repr(drift, volatility, t):
     assert isinstance(str(instance), str)
 
 
-def test_geometric_brownian_motion_sample(drift, volatility, t, n, zero, initial, threshold):
+def test_geometric_brownian_motion_sample(drift, volatility, t, n, initial, threshold):
     instance = GeometricBrownianMotion(drift, volatility, t)
-    s = instance.sample(n, initial, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n, initial)
+    assert len(s) == n + 1
 
 
 def test_geometric_brownian_motion_sample_at(drift, volatility, t, times, initial, threshold):

--- a/tests/continuous/test_inverse_gaussian.py
+++ b/tests/continuous/test_inverse_gaussian.py
@@ -10,16 +10,16 @@ def test_inverse_gaussian_process_str_repr(mean_func, scale, t):
     assert isinstance(str(instance), str)
 
 
-def test_inverse_gaussian_process_sample(mean_func, scale, t, n, zero):
+def test_inverse_gaussian_process_sample(mean_func, scale, t, n):
     instance = InverseGaussianProcess(mean_func, scale, t)
-    s = instance.sample(n, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n)
+    assert len(s) == n + 1
 
 
-def test_inverse_gaussian_process_sample_invalid(mean_func_invalid, scale, t, n, zero):
+def test_inverse_gaussian_process_sample_invalid(mean_func_invalid, scale, t, n):
     with pytest.raises(ValueError):
         instance = InverseGaussianProcess(mean_func_invalid, scale, t)
-        s = instance.sample(n, zero)
+        _ = instance.sample(n)
 
 
 def test_inverse_gaussian_process_sample_at(mean_func, scale, t, times):

--- a/tests/continuous/test_mixed_poisson.py
+++ b/tests/continuous/test_mixed_poisson.py
@@ -10,35 +10,35 @@ def test_mixed_poisson_process_str_repr(rate_func, rate_args, rate_kwargs):
     assert isinstance(str(instance), str)
 
 
-def test_mixed_poisson_process_sample(rate_func, rate_args, rate_kwargs, n_fixture, length, zero):
+def test_mixed_poisson_process_sample(rate_func, rate_args, rate_kwargs, n_fixture, length):
     instance = MixedPoissonProcess(rate_func, rate_args, rate_kwargs)
     if n_fixture is None and length is None:
         with pytest.raises(ValueError):
-            s = instance.sample(n_fixture, length, zero)
+            s = instance.sample(n_fixture, length)
     elif length is not None and n_fixture is None:
-        s = instance.sample(n_fixture, length, zero)
+        s = instance.sample(n_fixture, length)
         assert s[-1] >= length
     else:  # n_fixture is not None:
-        s = instance.sample(n_fixture, length, zero)
-        assert len(s) == n_fixture + int(zero)
+        s = instance.sample(n_fixture, length)
+        assert len(s) == n_fixture + 1
 
 
 def test_mixed_poisson_process_times(rate_func, rate_args, rate_kwargs, n):
     instance = MixedPoissonProcess(rate_func, rate_args, rate_kwargs)
     with pytest.raises(AttributeError):
-        times = instance.times(n)
+        _ = instance.times(n)
 
 
 def test_mixed_poisson_process_invalid_func(rate_func_invalid, rate_args, rate_kwargs, n):
     with pytest.raises(ValueError):
-        instance = MixedPoissonProcess(rate_func_invalid, rate_args, rate_kwargs)
+        _ = MixedPoissonProcess(rate_func_invalid, rate_args, rate_kwargs)
 
 
 def test_mixed_poisson_process_invalid_args(rate_func, rate_args_invalid, rate_kwargs, n):
     with pytest.raises(ValueError):
-        instance = MixedPoissonProcess(rate_func, rate_args_invalid, rate_kwargs)
+        _ = MixedPoissonProcess(rate_func, rate_args_invalid, rate_kwargs)
 
 
 def test_mixed_poisson_process_invalid_kwargs(rate_func, rate_args, rate_kwargs_invalid, n):
     with pytest.raises(ValueError):
-        instance = MixedPoissonProcess(rate_func, rate_args, rate_kwargs_invalid)
+        _ = MixedPoissonProcess(rate_func, rate_args, rate_kwargs_invalid)

--- a/tests/continuous/test_multifractional_brownian_motion.py
+++ b/tests/continuous/test_multifractional_brownian_motion.py
@@ -10,10 +10,10 @@ def test_multifractional_brownian_motion_str_repr(hurst_func, t):
     assert isinstance(str(instance), str)
 
 
-def test_multifractional_brownian_motion_sample(hurst_func, t, n, zero):
+def test_multifractional_brownian_motion_sample(hurst_func, t, n):
     instance = MultifractionalBrownianMotion(hurst_func, t)
-    s = instance.sample(n, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n)
+    assert len(s) == n + 1
 
 
 def test_multifractional_brownian_motion_invalid_hurst(hurst_invalid, t):

--- a/tests/continuous/test_poisson.py
+++ b/tests/continuous/test_poisson.py
@@ -10,20 +10,20 @@ def test_poisson_process_str_repr(rate):
     assert isinstance(str(instance), str)
 
 
-def test_poisson_process_sample(rate, n_fixture, length, zero):
+def test_poisson_process_sample(rate, n_fixture, length):
     instance = PoissonProcess(rate)
     if n_fixture is None and length is None:
         with pytest.raises(ValueError):
-            s = instance.sample(n_fixture, length, zero)
+            s = instance.sample(n_fixture, length)
     elif length is not None and n_fixture is None:
-        s = instance.sample(n_fixture, length, zero)
+        s = instance.sample(n_fixture, length)
         assert s[-1] >= length
     else:  # n_fixture is not None:
-        s = instance.sample(n_fixture, length, zero)
-        assert len(s) == n_fixture + int(zero)
+        s = instance.sample(n_fixture, length)
+        assert len(s) == n_fixture + 1
 
 
 def test_poisson_process_times(rate, n):
     instance = PoissonProcess(rate)
     with pytest.raises(AttributeError):
-        times = instance.times(n)
+        _ = instance.times(n)

--- a/tests/continuous/test_squared_bessel.py
+++ b/tests/continuous/test_squared_bessel.py
@@ -13,18 +13,18 @@ def test_squared_bessel_str_repr(dim, t):
 def test_squared_bessel_init(dim_fixture, t):
     if not isinstance(dim_fixture, int):
         with pytest.raises(TypeError):
-            instance = SquaredBesselProcess(dim_fixture, t)
+            _ = SquaredBesselProcess(dim_fixture, t)
     elif dim_fixture < 1:
         with pytest.raises(ValueError):
-            instance = SquaredBesselProcess(dim_fixture, t)
+            _ = SquaredBesselProcess(dim_fixture, t)
     else:
-        instance = SquaredBesselProcess(dim_fixture, t)
+        _ = SquaredBesselProcess(dim_fixture, t)
 
 
-def test_squared_bessel_sample(dim, t, n, zero):
+def test_squared_bessel_sample(dim, t, n):
     instance = SquaredBesselProcess(dim, t)
-    s = instance.sample(n, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n)
+    assert len(s) == n + 1
 
 
 def test_squared_bessel_sample_at(dim, t, times):

--- a/tests/continuous/test_variance_gamma.py
+++ b/tests/continuous/test_variance_gamma.py
@@ -16,10 +16,10 @@ def test_variance_gamma_str_repr(drift, variance, scale, t):
     assert isinstance(str(instance), str)
 
 
-def test_variance_gamma_sample(drift, variance, scale, t, n, zero, threshold):
+def test_variance_gamma_sample(drift, variance, scale, t, n, threshold):
     instance = VarianceGammaProcess(drift, variance, scale, t)
-    s = instance.sample(n, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n)
+    assert len(s) == n + 1
 
 
 def test_variance_gamma_sample_at(drift, variance, scale, t, times, threshold):

--- a/tests/diffusion/conftest.py
+++ b/tests/diffusion/conftest.py
@@ -19,11 +19,6 @@ def n(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def zero(request):
-    return request.param
-
-
 @pytest.fixture(params=[1])
 def initial(request):
     return request.param

--- a/tests/diffusion/test_constant_elasticity_variance.py
+++ b/tests/diffusion/test_constant_elasticity_variance.py
@@ -1,6 +1,4 @@
 """Constant elasticity of variance tests."""
-import pytest
-
 from stochastic.diffusion import ConstantElasticityVarianceProcess
 
 
@@ -10,7 +8,7 @@ def test_constant_elasticity_variance_str_repr(mu, sigma, gamma, t):
     assert isinstance(str(instance), str)
 
 
-def test_constant_elasticity_variance_sample(mu, sigma, gamma, t, n, initial, zero, threshold):
+def test_constant_elasticity_variance_sample(mu, sigma, gamma, t, n, initial, threshold):
     instance = ConstantElasticityVarianceProcess(mu, sigma, gamma, t)
-    s = instance.sample(n, initial, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n, initial)
+    assert len(s) == n + 1

--- a/tests/diffusion/test_cox_ingersoll_ross.py
+++ b/tests/diffusion/test_cox_ingersoll_ross.py
@@ -1,6 +1,4 @@
 """Cox-Ingersoll-Ross tests."""
-import pytest
-
 from stochastic.diffusion import CoxIngersollRossProcess
 
 
@@ -10,7 +8,7 @@ def test_cox_ingersoll_ross_str_repr(speed, mean, vol, t):
     assert isinstance(str(instance), str)
 
 
-def test_cox_ingersoll_ross_sample(speed, mean, vol, t, n, initial, zero, threshold):
+def test_cox_ingersoll_ross_sample(speed, mean, vol, t, n, initial, threshold):
     instance = CoxIngersollRossProcess(speed, mean, vol, t)
-    s = instance.sample(n, initial, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n, initial)
+    assert len(s) == n + 1

--- a/tests/diffusion/test_ornstein_uhlenbeck.py
+++ b/tests/diffusion/test_ornstein_uhlenbeck.py
@@ -1,6 +1,4 @@
 """Ornstein-Uhlenbeck tests."""
-import pytest
-
 from stochastic.diffusion import OrnsteinUhlenbeckProcess
 
 
@@ -10,7 +8,7 @@ def test_ornstein_uhlenbeck_str_repr(speed, mean, vol, t):
     assert isinstance(str(instance), str)
 
 
-def test_ornstein_uhlenbeck_sample(speed, mean, vol, t, n, initial, zero, threshold):
+def test_ornstein_uhlenbeck_sample(speed, mean, vol, t, n, initial, threshold):
     instance = OrnsteinUhlenbeckProcess(speed, mean, vol, t)
-    s = instance.sample(n, initial, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n, initial)
+    assert len(s) == n + 1

--- a/tests/diffusion/test_vasicek.py
+++ b/tests/diffusion/test_vasicek.py
@@ -1,10 +1,8 @@
 """Vasicek tests."""
-import pytest
-
 from stochastic.diffusion import VasicekProcess
 
 
-def test_ornstein_uhlenbeck_str_repr(speed, mean, vol, t):
+def test_vasicek_str_repr(speed, mean, vol, t):
     instance = VasicekProcess(speed, mean, vol, t)
     assert isinstance(repr(instance), str)
     assert isinstance(str(instance), str)

--- a/tests/discrete/conftest.py
+++ b/tests/discrete/conftest.py
@@ -19,11 +19,6 @@ def n(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def zero(request):
-    return request.param
-
-
 @pytest.fixture(params=[1])
 def initial(request):
     return request.param

--- a/tests/discrete/test_random_walk.py
+++ b/tests/discrete/test_random_walk.py
@@ -10,10 +10,10 @@ def test_random_walk_str_repr(steps, weights):
     assert isinstance(str(instance), str)
 
 
-def test_random_walk_sample(steps, weights, n, zero):
+def test_random_walk_sample(steps, weights, n):
     instance = RandomWalk(steps, weights)
-    s = instance.sample(n, zero)
-    assert len(s) == n + int(zero)
+    s = instance.sample(n)
+    assert len(s) == n + 1
 
 
 def test_random_walk_sample_increments(steps, weights, n):

--- a/tests/noise/conftest.py
+++ b/tests/noise/conftest.py
@@ -22,11 +22,6 @@ def n(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def zero(request):
-    return request.param
-
-
 # Generate some random times for the sample_at() method
 times_random = np.cumsum(np.abs(np.random.normal(size=16)))
 times_random_zero = np.cumsum([0] + list(np.abs(np.random.normal(size=16))))

--- a/tests/noise/test_colored_noise.py
+++ b/tests/noise/test_colored_noise.py
@@ -1,5 +1,4 @@
 """Test ColoredNoise."""
-import pytest
 
 
 def test_colored_noise_str_repr(t, colored_noise_class):

--- a/tests/noise/test_fractional_gaussian_noise.py
+++ b/tests/noise/test_fractional_gaussian_noise.py
@@ -2,7 +2,6 @@
 import pytest
 
 from stochastic.noise import FractionalGaussianNoise
-from stochastic.noise import fractional_gaussian_noise
 
 
 def test_fractional_gaussian_noise_str_repr(hurst, t):
@@ -13,16 +12,16 @@ def test_fractional_gaussian_noise_str_repr(hurst, t):
 
 def test_fractional_gaussian_noise_hurst(hurst_fixture, t):
     with pytest.raises((ValueError, TypeError)):
-        instance = FractionalGaussianNoise(hurst_fixture, t)
+        _ = FractionalGaussianNoise(hurst_fixture, t)
 
 
 def test_fractional_gaussian_noise_algorithm(t, n, algorithm_fixture):
     instance = FractionalGaussianNoise(0.7, t)
     with pytest.raises(ValueError):
-        s = instance.sample(n, algorithm_fixture)
+        _ = instance.sample(n, algorithm_fixture)
 
 
-def test_fractional_gaussian_noise_sample(hurst, t, algorithm, n, zero):
+def test_fractional_gaussian_noise_sample(hurst, t, algorithm, n):
     instance = FractionalGaussianNoise(hurst, t)
     s = instance.sample(n, algorithm)
     assert len(s) == n

--- a/tests/noise/test_gaussian_noise.py
+++ b/tests/noise/test_gaussian_noise.py
@@ -1,6 +1,4 @@
 """Test GaussianNoise."""
-import pytest
-
 from stochastic.noise import GaussianNoise
 
 
@@ -10,7 +8,7 @@ def test_gaussian_noise_str_repr(t):
     assert isinstance(str(instance), str)
 
 
-def test_gaussian_noise_sample(t, n, zero):
+def test_gaussian_noise_sample(t, n):
     instance = GaussianNoise(t)
     s = instance.sample(n)
     assert len(s) == n
@@ -23,12 +21,3 @@ def test_gaussian_noise_sample_at(t, times):
         assert len(s) == len(times) - 1
     else:
         assert len(s) == len(times)
-
-
-def test_gaussian_noise_sample_at_zero(t, times):
-    instance = GaussianNoise(t)
-    s = instance._sample_gaussian_noise_at(times, zero=True)
-    if times[0] == 0:
-        assert len(s) == len(times)
-    else:
-        assert len(s) == len(times) + 1


### PR DESCRIPTION
Remove zero arg options from all APIs. This clutters up the method signatures and related code. End users can always drop the first array elements if they don't care about the initial value of the process being zero.