### PR TITLE
Do not install text files in the root of the site-packages directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 include = [
-    "CHANGELOG.rst",
-    "CONTRIBUTORS.rst",
-    "LICENSE.txt"
+    { path="CHANGELOG.rst", format="sdist" },
+    { path="CONTRIBUTORS.rst", format="sdist" },
+    { path="LICENSE.txt", format="sdist" }
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
These text files are still included in the .tar.gz but they are not installed in the root of the Python site-packages directory.